### PR TITLE
Improvement/audience can accept list of string

### DIFF
--- a/lib/corsac_jwt.dart
+++ b/lib/corsac_jwt.dart
@@ -133,7 +133,7 @@ class JWT {
   String get issuer => _claims['iss'];
 
   /// The audience of this token (value of standard `aud` claim).
-  String get audience => _claims['aud'];
+  List<String> get audience => _claims['aud'].cast<String>();
 
   /// The time this token was issued (value of standard `iat` claim).
   int get issuedAt => _claims['iat'];
@@ -185,8 +185,12 @@ class JWTBuilder {
   }
 
   /// Token audience (standard `aud` claim).
-  void set audience(String audience) {
-    _claims['aud'] = audience;
+  void set audience(dynamic audience) {
+    if (audience is String) {
+      _claims['aud'] = [audience];
+    } else if (audience is List<String>) {
+      _claims['aud'] = audience;
+    }
   }
 
   /// Token issued at timestamp in seconds (standard `iat` claim).
@@ -333,7 +337,7 @@ class JWTValidator {
       errors.add('The token issuer is invalid.');
     }
 
-    if (audience is String && audience != token.audience) {
+    if (audience is String && !token.audience.contains(audience)) {
       errors.add('The token audience is invalid.');
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   asn1lib: "^0.5.0"
   logging: "^0.11.3"
-#  pointycastle: "1.0.0-rc2"
-#  rsa_pkcs: "^0.1.2"
+  #  pointycastle: "1.0.0-rc2"
+  #  rsa_pkcs: "^0.1.2"
   crypto: "^2.0.0"
 
 dev_dependencies:

--- a/test/jwt_test.dart
+++ b/test/jwt_test.dart
@@ -95,6 +95,20 @@ void main() {
       expect(token.algorithm, equals('none'));
     });
 
+    test('it supports all standard claims when the aud is string', () {
+      builder.audience = 'people';
+      var token = builder.getToken();
+      expect(token, const TypeMatcher<JWT>());
+      expect(token.issuer, equals('https://mycompany.com'));
+      expect(token.audience, contains('people'));
+      expect(token.issuedAt, equals(_secondsSinceEpoch(now)));
+      expect(token.expiresAt, equals(_secondsSinceEpoch(now) + 10));
+      expect(token.notBefore, equals(_secondsSinceEpoch(now) + 5));
+      expect(token.id, equals('identifier'));
+      expect(token.subject, equals('subj'));
+      expect(token.algorithm, equals('none'));
+    });
+
     test('it prevents setting standard claims using setClaim', () {
       expect(() => builder.setClaim('iss', 'bad'), throwsArgumentError);
     });

--- a/test/jwt_test.dart
+++ b/test/jwt_test.dart
@@ -17,7 +17,7 @@ void main() {
       builder = new JWTBuilder();
       builder
         ..issuer = 'https://mycompany.com'
-        ..audience = 'people'
+        ..audience = ['people']
         ..issuedAt = now
         ..expiresAt = now.add(new Duration(seconds: 10))
         ..notBefore = now.add(new Duration(seconds: 5))
@@ -86,7 +86,7 @@ void main() {
       var token = builder.getToken();
       expect(token, const TypeMatcher<JWT>());
       expect(token.issuer, equals('https://mycompany.com'));
-      expect(token.audience, equals('people'));
+      expect(token.audience.contains('people'), equals(true));
       expect(token.issuedAt, equals(_secondsSinceEpoch(now)));
       expect(token.expiresAt, equals(_secondsSinceEpoch(now) + 10));
       expect(token.notBefore, equals(_secondsSinceEpoch(now) + 5));


### PR DESCRIPTION
Because some oAuth2 and OIDC services can also return a list of audiences, not just a String.
Example: https://github.com/ory/hydra