### PR TITLE
Migrate to null safety

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,15 @@ sudo: false
 language: dart
 
 dart:
-- stable
+- beta
 - dev
 
 script:
   - pub get
-  - pub run test -r expanded
+  - pub run --no-sound-null-safety test -r expanded
   - dartfmt -n --set-exit-if-changed lib/
   - dart analyze --fatal-infos --fatal-warnings .
-  - pub run test_coverage
+  - pub run --no-sound-null-safety test_coverage
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ dart:
 
 script:
   - pub get
-  - pub run --no-sound-null-safety test -r expanded
+  - pub run test -r expanded
   - dartfmt -n --set-exit-if-changed lib/
   - dart analyze --fatal-infos --fatal-warnings .
-  - pub run --no-sound-null-safety test_coverage
+  - pub run test_coverage
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: dart
 
 dart:
-- beta
+- stable
 - dev
 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+- Support null safety (#21)
+
 ## 0.4.0
 
 - Allow setting custom headers. See `JWTBuilder.setHeader` for details.

--- a/lib/corsac_jwt.dart
+++ b/lib/corsac_jwt.dart
@@ -41,8 +41,8 @@ import 'src/utils.dart';
 final _logger = Logger('JWTRsaSha256Signer');
 
 class JWTRsaSha256Signer implements JWTSigner {
-  final rsa.RSAPrivateKey _privateKey;
-  final rsa.RSAPublicKey _publicKey;
+  final rsa.RSAPrivateKey? _privateKey;
+  final rsa.RSAPublicKey? _publicKey;
 
   JWTRsaSha256Signer._(this._privateKey, this._publicKey);
 
@@ -55,11 +55,11 @@ class JWTRsaSha256Signer implements JWTSigner {
   /// Both `privateKey` and `publicKey` are expected to be strings in PEM
   /// format.
   factory JWTRsaSha256Signer(
-      {String privateKey, String publicKey, String password}) {
+      {String? privateKey, String? publicKey, String? password}) {
     final parser = rsa.RSAPKCSParser();
 
-    rsa.RSAPrivateKey priv;
-    rsa.RSAPublicKey pub;
+    rsa.RSAPrivateKey? priv;
+    rsa.RSAPublicKey? pub;
     if (privateKey is String) {
       final pair = parser.parsePEM(privateKey, password: password);
       if (pair.private is! rsa.RSAPrivateKey) {
@@ -88,8 +88,8 @@ class JWTRsaSha256Signer implements JWTSigner {
           'RS256 signer requires private key to create signatures.');
     }
     final s = Signer('SHA-256/RSA');
-    final key = RSAPrivateKey(_privateKey.modulus, _privateKey.privateExponent,
-        _privateKey.prime1, _privateKey.prime2);
+    final key = RSAPrivateKey(_privateKey!.modulus,
+        _privateKey!.privateExponent, _privateKey!.prime1, _privateKey!.prime2);
     final param = ParametersWithRandom(
       PrivateKeyParameter<RSAPrivateKey>(key),
       SecureRandom('AES/CTR/PRNG'),
@@ -112,7 +112,7 @@ class JWTRsaSha256Signer implements JWTSigner {
     try {
       final s = Signer('SHA-256/RSA');
       final key = RSAPublicKey(
-          _publicKey.modulus, BigInt.from(_publicKey.publicExponent));
+          _publicKey!.modulus, BigInt.from(_publicKey!.publicExponent));
       final param = ParametersWithRandom(
         PublicKeyParameter<RSAPublicKey>(key),
         SecureRandom('AES/CTR/PRNG'),
@@ -205,7 +205,7 @@ class JWT {
 
   /// Contains original Base64 encoded token signature, or `null`
   /// if token is unsigned.
-  final String signature;
+  final String? signature;
 
   JWT._(this.encodedHeader, this.encodedPayload, this.signature)
       : headers = Map.unmodifiable(_decode(encodedHeader)),
@@ -229,30 +229,30 @@ class JWT {
   ///
   /// One should not rely on this value to determine the algorithm used to sign
   /// this token.
-  String get algorithm => headers['alg'];
+  String? get algorithm => headers['alg'];
 
   /// The issuer of this token (value of standard `iss` claim).
-  String get issuer => _claims['iss'] as String;
+  String? get issuer => _claims['iss'] as String?;
 
   /// The audience of this token (value of standard `aud` claim).
-  String get audience => _claims['aud'] as String;
+  String? get audience => _claims['aud'] as String?;
 
   /// The time this token was issued (value of standard `iat` claim).
-  int get issuedAt => _claims['iat'] as int;
+  int? get issuedAt => _claims['iat'] as int?;
 
   /// The expiration time of this token (value of standard `exp` claim).
-  int get expiresAt => _claims['exp'] as int;
+  int? get expiresAt => _claims['exp'] as int?;
 
   /// The time before which this token must not be accepted (value of standard
   /// `nbf` claim).
-  int get notBefore => _claims['nbf'] as int;
+  int? get notBefore => _claims['nbf'] as int?;
 
   /// Identifies the principal that is the subject of this token (value of
   /// standard `sub` claim).
-  String get subject => _claims['sub'] as String;
+  String? get subject => _claims['sub'] as String?;
 
   /// Unique identifier of this token (value of standard `jti` claim).
-  String get id => _claims['jti'] as String;
+  String? get id => _claims['jti'] as String?;
 
   @override
   String toString() {
@@ -266,10 +266,15 @@ class JWT {
 
   /// Verifies this token's signature using [signer].
   ///
-  /// Returns `true` if signature is valid and `false` otherwise.
+  /// Returns `true` if token is signed and signature is valid, and `false`
+  /// otherwise.
   bool verify(JWTSigner signer) {
+    if (signature == null) {
+      return false;
+    }
+
     final body = utf8.encode('$encodedHeader.$encodedPayload');
-    final sign = base64Url.decode(_base64Padded(signature));
+    final sign = base64Url.decode(_base64Padded(signature!));
     return signer.verify(body, sign);
   }
 
@@ -418,14 +423,14 @@ class JWTHmacSha256Signer implements JWTSigner {
 class JWTValidator {
   /// Current time used to validate token's `iat`, `exp` and `nbf` claims.
   final DateTime currentTime;
-  String issuer;
-  String audience;
-  String subject;
-  String id;
+  String? issuer;
+  String? audience;
+  String? subject;
+  String? id;
 
   /// Creates new validator. One can supply custom value for [currentTime]
-  /// parameter, if not the `DateTime.now()` value is used by default.
-  JWTValidator({DateTime currentTime})
+  /// parameter, if not [DateTime.now] is used by default.
+  JWTValidator({DateTime? currentTime})
       : currentTime = currentTime ?? DateTime.now();
 
   /// Validates provided [token] and returns a list of validation errors.
@@ -434,39 +439,40 @@ class JWTValidator {
   /// If [signer] parameter is provided then token signature
   /// will also be verified. Otherwise signature must be verified manually using
   /// [JWT.verify] method.
-  Set<String> validate(JWT token, {JWTSigner signer}) {
-    final errors = <String>{};
 
+  Set<String> validate(JWT token, {JWTSigner? signer}) {
+    final errors = <String>{};
     final currentTimestamp = secondsSinceEpoch(currentTime);
-    if (token.expiresAt is int && currentTimestamp >= token.expiresAt) {
+
+    if (token.expiresAt != null && currentTimestamp >= token.expiresAt!) {
       errors.add('The token has expired.');
     }
 
-    if (token.issuedAt is int && currentTimestamp < token.issuedAt) {
+    if (token.issuedAt != null && currentTimestamp < token.issuedAt!) {
       errors.add('The token issuedAt time is in future.');
     }
 
-    if (token.notBefore is int && currentTimestamp < token.notBefore) {
+    if (token.notBefore != null && currentTimestamp < token.notBefore!) {
       errors.add('The token can not be accepted due to notBefore policy.');
     }
 
-    if (issuer is String && issuer != token.issuer) {
+    if (issuer != null && issuer != token.issuer) {
       errors.add('The token issuer is invalid.');
     }
 
-    if (audience is String && audience != token.audience) {
+    if (audience != null && audience != token.audience) {
       errors.add('The token audience is invalid.');
     }
 
-    if (subject is String && subject != token.subject) {
+    if (subject != null && subject != token.subject) {
       errors.add('The token subject is invalid.');
     }
 
-    if (id is String && id != token.id) {
+    if (id != null && id != token.id) {
       errors.add('The token unique identifier is invalid.');
     }
 
-    if (signer is JWTSigner && !token.verify(signer)) {
+    if (signer != null && !token.verify(signer)) {
       errors.add('The token signature is invalid.');
     }
 

--- a/lib/corsac_jwt.dart
+++ b/lib/corsac_jwt.dart
@@ -33,7 +33,9 @@ import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
 import 'package:logging/logging.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import 'package:pointycastle/pointycastle.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import 'package:rsa_pkcs/rsa_pkcs.dart' as rsa;
 
 import 'src/utils.dart';

--- a/lib/corsac_jwt.dart
+++ b/lib/corsac_jwt.dart
@@ -32,10 +32,8 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
-// ignore: import_of_legacy_library_into_null_safe
 import 'package:logging/logging.dart';
 import 'package:pointycastle/pointycastle.dart';
-// ignore: import_of_legacy_library_into_null_safe
 import 'package:rsa_pkcs/rsa_pkcs.dart' as rsa;
 
 import 'src/utils.dart';

--- a/lib/corsac_jwt.dart
+++ b/lib/corsac_jwt.dart
@@ -32,8 +32,8 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
-import 'package:logging/logging.dart';
 // ignore: import_of_legacy_library_into_null_safe
+import 'package:logging/logging.dart';
 import 'package:pointycastle/pointycastle.dart';
 // ignore: import_of_legacy_library_into_null_safe
 import 'package:rsa_pkcs/rsa_pkcs.dart' as rsa;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,16 +9,17 @@ environment:
 
 dependencies:
   asn1lib: ^0.9.0-nullsafety.0
-  crypto: ^3.0.0-nullsafety.0
-  logging: ^1.0.0-nullsafety.0
-  pointycastle: ^2.0.0
+  crypto: ^3.0.0
+  logging: ^1.0.0
+  pointycastle: ^3.0.0-nullsafety.2
   rsa_pkcs: ^1.1.4
 
 dev_dependencies:
-  pedantic: ^1.10.0-nullsafety.3
-  test: ^1.16.0-nullsafety.17
+  pedantic: ^1.11.0
+  test: ^1.16.5
   test_coverage: ^0.5.0
 
 dependency_overrides:
   asn1lib: ^0.9.0-nullsafety.0
-  logging: ^1.0.0-nullsafety.0
+  logging: ^1.0.0
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   crypto: ^3.0.0
   logging: ^1.0.0
   pointycastle: ^3.0.0
-  rsa_pkcs: ^1.1.4
+  rsa_pkcs: ^2.0.0
 
 dev_dependencies:
   pedantic: ^1.11.0
@@ -20,6 +20,5 @@ dev_dependencies:
   test_coverage: ^0.5.0
 
 dependency_overrides:
-  asn1lib: ^0.9.0-nullsafety.0
   logging: ^1.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,15 +9,15 @@ environment:
 
 dependencies:
   asn1lib: ^0.9.0-nullsafety.0
+  crypto: ^3.0.0-nullsafety.0
   logging: ^1.0.0-nullsafety.0
   pointycastle: ^2.0.0
   rsa_pkcs: ^1.1.4
-  crypto: ^3.0.0-nullsafety.0
 
 dev_dependencies:
+  pedantic: ^1.10.0-nullsafety.3
   test: ^1.16.0-nullsafety.17
   test_coverage: ^0.5.0
-  pedantic: ^1.10.0-nullsafety.3
 
 dependency_overrides:
   asn1lib: ^0.9.0-nullsafety.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,16 +5,20 @@ homepage: https://github.com/corsac-dart/jwt
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
 
 environment:
-  sdk: ">=2.2.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
-  asn1lib: "^0.8.1"
-  crypto: "^2.1.5"
-  logging: "^0.11.4"
-  pointycastle: "^2.0.0"
-  rsa_pkcs: "^1.1.4"
+  asn1lib: ^0.9.0-nullsafety.0
+  logging: ^1.0.0-nullsafety.0
+  pointycastle: ^2.0.0
+  rsa_pkcs: ^1.1.4
+  crypto: ^3.0.0-nullsafety.0
 
 dev_dependencies:
-  pedantic: "^1.9.2"
-  test: "^1.15.4"
-  test_coverage: "^0.5.0"
+  test: ^1.16.0-nullsafety.17
+  test_coverage: ^0.5.0
+  pedantic: ^1.10.0-nullsafety.3
+
+dependency_overrides:
+  asn1lib: ^0.9.0-nullsafety.0
+  logging: ^1.0.0-nullsafety.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: corsac_jwt
-version: 0.4.1-dev
+version: 1.0.0-nullsafety.1
 description: Lightweight implementation of JSON Web Tokens (JWT).
 homepage: https://github.com/corsac-dart/jwt
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,10 +8,10 @@ environment:
   sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
-  asn1lib: ^0.9.0-nullsafety.0
+  asn1lib: ^1.0.0
   crypto: ^3.0.0
   logging: ^1.0.0
-  pointycastle: ^3.0.0-nullsafety.2
+  pointycastle: ^3.0.0
   rsa_pkcs: ^1.1.4
 
 dev_dependencies:

--- a/test/jwt_test.dart
+++ b/test/jwt_test.dart
@@ -6,11 +6,10 @@ import 'package:test/test.dart';
 
 void main() {
   group('$JWT', () {
-    DateTime now;
-    JWTBuilder builder;
+    final now = DateTime.now();
+    late JWTBuilder builder;
 
     setUp(() {
-      now = DateTime.now();
       builder = JWTBuilder()
         ..issuer = 'https://mycompany.com'
         ..audience = 'people'

--- a/test/rs256_test.dart
+++ b/test/rs256_test.dart
@@ -5,12 +5,9 @@ import 'package:test/test.dart';
 
 void main() {
   group('RS256: ', () {
-    JWTRsaSha256Signer signer;
-    setUp(() {
-      final priv = File('test/resources/private.pem').readAsStringSync();
-      final pub = File('test/resources/public.pem').readAsStringSync();
-      signer = JWTRsaSha256Signer(privateKey: priv, publicKey: pub);
-    });
+    final priv = File('test/resources/private.pem').readAsStringSync();
+    final pub = File('test/resources/public.pem').readAsStringSync();
+    final signer = JWTRsaSha256Signer(privateKey: priv, publicKey: pub);
 
     test('it can sign and verify JWT with RS256', () {
       final builder = JWTBuilder()


### PR DESCRIPTION
Migrates the library to NNBD.

Null-safety is not sound because `rsa_pkcs` and `pointycastle` have not yet been migrated to NNBD.
However, because `corsac_jwt` does not export anything from those libraries and there's very little code using them, and that code looks to be null-safe, there's no harm in using them like this.

I migrated this library because I depend on it in a project and had a conflicting dependency on `crypto` (because another library I depend on depended on the null-safe preview version of `crypto`).

The issue can be worked around by adding a dependency_override for `crypto`, so if you prefer you could hold off merging this until both `rsa_pkcs` and `pointycastle` have migrated as well.

EDIT: All (non-dev) dependencies have been migrated, so this branch is now sound null-safe.